### PR TITLE
Allow lsp server to connect via stdio

### DIFF
--- a/bin/typeprof
+++ b/bin/typeprof
@@ -6,9 +6,18 @@ case ARGV[0]
 when "--version"
   puts "typeprof 0.30.0"
 when "--lsp"
+  mode = ARGV[1]&.to_sym || :socket
+
   core = TypeProf::Core::Service.new
   begin
-    TypeProf::LSP::Server.start_socket(core)
+    case mode
+    when :socket
+      TypeProf::LSP::Server.start_socket(core)
+    when :stdio
+      TypeProf::LSP::Server.start_stdio(core)
+    else
+      puts "lsp mode '#{mode}' is not supported. expected mode: socket, stdio"
+    end
   rescue Exception
     puts $!.detailed_message(highlight: false)
     raise


### PR DESCRIPTION
## summary

At this point, typeprof2 (as lsp client) accept message via TCP socket.
I'm not sure which transport mechanism is major with VS Code, but stdio is the default option on nvim (at least I know)
Ref: https://neovim.io/doc/user/lsp.html#lsp-rpc

So, It's not a bad idea to allow communication via stdio, and even typeprof2 has impl for stdio, why not ;)

## how to select mode

This PR add arg following to --lsp opt as simplexity, but on typeprof(v1), lsp option is provided by `--lsp --stdio` or `--lsp --port xxx`.

```
$ typeprof --help
Usage: typeprof [options] files...

...
        --lsp                        LSP mode

...

LSP options:
        --port PORT                  Specify a port number to listen for requests on
        --stdio                      Use stdio for LSP transport
```

Should I keep current typeprof(v1) option style, or not? 🤔 
(maybe It's the time to impl CLI parser.....)